### PR TITLE
#145799393 Expose API endpoints for CRUD operations for events

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ import mongoose from 'mongoose';
 
 // Get our API routes
 import userRoute from './server/routes/users.routes';
+import eventRoute from './server/routes/events.routes';
 
 const app = express();
 
@@ -37,6 +38,7 @@ db.once('open', () => {
 
 // Set our api routes
 app.use('/api/users', userRoute);
+app.use('/api/events', eventRoute);
 
 // Catch all other routes and return the index file
 app.get('*', (req, res) => {

--- a/server/controllers/event.controllers.js
+++ b/server/controllers/event.controllers.js
@@ -1,0 +1,167 @@
+import Event from '../models/event.models';
+
+/**
+ * This class handles database CRUD operations for events collection
+ */
+class EventController {
+  /**
+   * Method to create an event
+   * @param {Object} req
+   * @param {Object} res
+   * @returns {Object} res object
+   */
+  static createEvent(req, res) {
+    // check request body for event name
+    Event.findOne({ eventName: req.body.eventName }, (error, oldEvent) => {
+      if (error) {
+        return res.status(500)
+          .send({
+            success: false,
+            message: 'An error occured',
+            error
+          });
+      } else if (oldEvent) {
+        return res.status(409)
+          .send({
+            success: false,
+            message: `Event ${req.body.eventName} already exists`,
+            error
+          });
+      }
+      // create event
+      const newEvent = new Event(req.body);
+      newEvent.save((err) => {
+        if (err) {
+          return res.status(400)
+            .send({
+              success: false,
+              message: 'An error occured creating the event',
+              err
+            });
+        }
+
+        return res.status(201)
+          .send({
+            success: true,
+            message: 'New event created',
+            newEvent
+          });
+      });
+    });
+  }
+
+  /**
+   * Method to get all users in the db
+   *
+   * @param {Object} req
+   * @param {Object} res
+   * @return {Object} res object
+   */
+  static getAllEvents(req, res) {
+    Event.find({}, (error, events) => {
+      if (error) {
+        return res.status(500)
+          .send({
+            success: false,
+            message: 'An error occured getting all events',
+            error
+          });
+      }
+
+      return res.status(200)
+        .send({
+          success: true,
+          events
+        });
+    });
+  }
+
+  /**
+   * Method to update an event
+   * @param {Object} req
+   * @param {Object} res
+   * @return {Object} res object
+   */
+  static updateEvent(req, res) {
+    Event.findByIdAndUpdate(req.params.id, req.body, { new: true }, (error, updatedEvent) => {
+      if (error) {
+        return res.status(500)
+          .send({
+            success: false,
+            message: 'An error occured',
+            error
+          });
+      } else if (!updatedEvent) {
+        // return event not found
+        return res.status(404)
+          .send({
+            success: false,
+            message: 'Update failed! User not found'
+          });
+      }
+      // return updated event
+      return res.status(201)
+        .send({
+          success: true,
+          message: 'Event succesfully updated',
+          updatedEvent
+        });
+    });
+  }
+
+  /**
+   * Method to get an event by ID
+   * @param {Object} req
+   * @param {Object} res
+   * @return {Object} res object
+   */
+  static getEventByID(req, res) {
+    Event.findById(req.params.id, (error, foundEvent) => {
+      if (error) {
+        return res.status(500)
+          .send({
+            success: false,
+            message: 'An error occured',
+            error
+          });
+      } else if (!foundEvent) {
+        return res.status(404)
+          .send({
+            success: false,
+            message: 'Event not found'
+          });
+      }
+      return res.status(200)
+        .send({
+          success: true,
+          foundEvent
+        });
+    });
+  }
+
+  /**
+   * Method to delete an event
+   * @param {Object} req
+   * @param {Object} res
+   * @return {Object} res object
+   */
+  static deleteEvent(req, res) {
+    Event.findByIdAndRemove(req.params.id, (error) => {
+      if (error) {
+        return res.status(500)
+          .send({
+            success: false,
+            message: 'An error occured',
+            error
+          });
+      }
+      return res.status(201)
+        .send({
+          success: true,
+          message: 'Event successfully deleted'
+        });
+    });
+  }
+}
+
+export default EventController;

--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -36,7 +36,6 @@ class UserController {
       // create user
       const newUser = new User(req.body);
       newUser.provider = 'local';
-      newUser.isAdmin = false;
       newUser.save((err) => {
         if (err) {
           return res.status(400)

--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -18,13 +18,13 @@ class UserController {
    */
   static createUser(req, res) {
     // check request body for username
-    User.findOne({ email: req.body.email }, (err, oldUser) => {
-      if (err) {
+    User.findOne({ email: req.body.email }, (error, oldUser) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured',
-            err
+            error
           });
       } else if (oldUser) {
         return res.status(409)
@@ -81,14 +81,13 @@ class UserController {
    * @return {Object} res object
    */
   static getAllUsers(req, res) {
-    // test first --> works
-    User.find({}, (err, users) => {
-      if (err) {
+    User.find({}, (error, users) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured getting all users',
-            err
+            error
           });
       }
 
@@ -107,13 +106,13 @@ class UserController {
    * @return {Object} res object
    */
   static signIn(req, res) {
-    User.findOne({ email: req.body.email }, (err, oldUser) => {
-      if (err) {
+    User.findOne({ email: req.body.email }, (error, oldUser) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured',
-            err
+            error
           });
       } else if (!oldUser) {
         // return user not found
@@ -155,17 +154,15 @@ class UserController {
    * @return {Object} res object
    */
   static updateUser(req, res) {
-    // add updatedAt field to the req body
-    req.body.updatedAt = new Date().toLocaleDateString();
-    User.findByIdAndUpdate(req.params.id, req.body, { new: true }, (err, oldUser) => {
-      if (err) {
+    User.findByIdAndUpdate(req.params.id, req.body, { new: true }, (error, updatedUser) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured',
-            err
+            error
           });
-      } else if (!oldUser) {
+      } else if (!updatedUser) {
         // return user not found
         return res.status(404)
           .send({
@@ -179,14 +176,14 @@ class UserController {
           success: true,
           message: 'User succesfully updated',
           oldUser: {
-            __v: oldUser.__v,
-            id: oldUser._id,
-            username: oldUser.username,
-            email: oldUser.email,
-            isAdmin: oldUser.isAdmin,
-            provider: oldUser.provider,
-            createdAt: oldUser.createdAt,
-            updatedAt: oldUser.updatedAt
+            __v: updatedUser.__v,
+            id: updatedUser._id,
+            username: updatedUser.username,
+            email: updatedUser.email,
+            isAdmin: updatedUser.isAdmin,
+            provider: updatedUser.provider,
+            createdAt: updatedUser.createdAt,
+            updatedAt: updatedUser.updatedAt
           }
         });
     });
@@ -199,13 +196,13 @@ class UserController {
    * @return {Object} res object
    */
   static getUserById(req, res) {
-    User.findById(req.params.id, (err, foundUser) => {
-      if (err) {
+    User.findById(req.params.id, (error, foundUser) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured',
-            err
+            error
           });
       } else if (!foundUser) {
         return res.status(404)
@@ -238,15 +235,13 @@ class UserController {
    * @return {Object} res object
    */
   static deleteUser(req, res) {
-    // first ensure user exists before deleting
-    // abstract this
-    User.findByIdAndRemove(req.params.id, (err) => {
-      if (err) {
+    User.findByIdAndRemove(req.params.id, (error) => {
+      if (error) {
         return res.status(500)
           .send({
             success: false,
             message: 'An error occured',
-            err
+            error
           });
       }
       return res.status(201)

--- a/server/models/event.models.js
+++ b/server/models/event.models.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+mongoose.Promise = require('bluebird');
+
+const EventSchema = new Schema({
+  name: {
+    type: String,
+    required: true
+  },
+  date: {
+    type: Date,
+    required: true
+  },
+  location: {
+    address: String,
+    state: String,
+    city: String
+  },
+  attendees: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  isPrivate: {
+    type: Boolean,
+    default: false
+  },
+  imageUrl: String
+});
+
+const Event = mongoose.model('Event', EventSchema);
+
+export default Event;

--- a/server/models/event.models.js
+++ b/server/models/event.models.js
@@ -5,15 +5,17 @@ const Schema = mongoose.Schema;
 mongoose.Promise = require('bluebird');
 
 const EventSchema = new Schema({
-  name: {
+  eventName: {
     type: String,
-    required: true
+    unique: true,
+    required: true,
+    trim: true
   },
-  date: {
+  eventDate: {
     type: Date,
     required: true
   },
-  location: {
+  eventLocation: {
     address: String,
     state: String,
     city: String
@@ -24,6 +26,8 @@ const EventSchema = new Schema({
     default: false
   },
   imageUrl: String
+}, {
+  timestamps: true
 });
 
 const Event = mongoose.model('Event', EventSchema);

--- a/server/models/user.models.js
+++ b/server/models/user.models.js
@@ -30,12 +30,15 @@ const UserSchema = new Schema({
     type: String,
     enum: ['twitter', 'facebook', 'google', 'local']
   },
-  isAdmin: Boolean,
+  isAdmin: {
+    type: Boolean,
+    default: false
+  },
   twitter: {},
   facebook: {},
-  google: {},
-  createdAt: Date,
-  updatedAt: Date
+  google: {}
+}, {
+  timestamps: true
 });
 
 // add date and perform validation on name and password
@@ -44,21 +47,8 @@ const UserSchema = new Schema({
 // check this out for more info
 // https://stackoverflow.com/questions/37365038/this-is-undefined-in-a-mongoose-pre-save-hook
 UserSchema.pre('save', function (next) {
-  // add the date field before saving
-  // gives us the current time in Nigeria
-  const currentDate = new Date().toLocaleString();
-
-  // change the updated_at field to current date
-  this.updatedAt = currentDate;
-
-  // if createdAt doesn't exist, add to that field
-  if (!this.createdAt) {
-    this.createdAt = currentDate;
-  }
-
   // hash password
   this.password = this.encryptPassword(this.password);
-
   next();
 });
 

--- a/server/routes/events.routes.js
+++ b/server/routes/events.routes.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import EventController from '../controllers/event.controllers';
+
+const router = express.Router();
+
+router.route('/')
+  .get(EventController.getAllEvents)
+  .post(EventController.createEvent);
+
+router.route('/:id')
+  .get(EventController.getEventByID)
+  .put(EventController.updateEvent)
+  .delete(EventController.deleteEvent);
+
+export default router;


### PR DESCRIPTION
#### What does this PR do?
This PR adds a `/events` endpoint that supports CRUD operations for events. The endpoints added are as follows
- `GET /events` : Gets all events
- `POST /events` : Creates a new event
- `GET /event/:id` : Gets a particular event 
- `PUT /event/:id` : Updates an event
- `DELETE /event/:id` : Deletes an event

#### Description of Task to be completed?
Create API endpoints that can be used for CRUD operations on users

#### How should this be manually tested?
Make sure the server is running on `localhost:3000` by running `npm run start-server`. Use Postman to hit any of the endpoints mentioned above and you should get a response

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#145799393
#### Screenshots (if appropriate)
<img width="962" alt="screen shot 2017-06-06 at 00 35 25" src="https://cloud.githubusercontent.com/assets/24937453/26807725/1a9fe5be-4a50-11e7-844d-7e5f509c5c86.png">

#### Questions:
N/A