### PR TITLE
#145799393 Reference User schema in Event schema

### DIFF
--- a/server/models/event.models.js
+++ b/server/models/event.models.js
@@ -37,6 +37,11 @@ const EventSchema = new Schema({
     default: false
   },
   attendees: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  eventOwner: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
   isPrivate: {
     type: Boolean,
     default: false


### PR DESCRIPTION
#### What does this PR do?
This PR adds an extra field `eventOwner` to the event schema. This field references the User schema

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
Currently events don't have owners so there is no way to know which user owns which event

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions: